### PR TITLE
Add magic link login support

### DIFF
--- a/backend/src/graphql/resolvers/auth.resolvers.js
+++ b/backend/src/graphql/resolvers/auth.resolvers.js
@@ -20,6 +20,7 @@ const {
   loginSchema,
   signupSchema,
   socialLoginSchema,
+  magicLinkRequestSchema,
 } = require('../../validators/auth.validators');
 
 const authResolvers = {
@@ -564,6 +565,109 @@ const authResolvers = {
         
         // For other errors, throw a generic error
         throw new Error(`Social authentication failed: ${error.message}`);
+      }
+    },
+
+    async requestMagicLink(parent, { input }, context) {
+      const { req } = context;
+
+      try {
+        await rateLimitCheck(req, 'magic_link_request', 5, 3600);
+
+        const { error, value } = validateInput(magicLinkRequestSchema, input);
+        if (error) {
+          throw new UserInputError('Validation failed', {
+            errors: error.details.map(detail => ({
+              field: detail.path.join('.'),
+              message: detail.message,
+              code: 'VALIDATION_ERROR'
+            }))
+          });
+        }
+
+        const { email, redirectUri } = value;
+        const user = await UserService.findByEmail(email);
+
+        if (!user) {
+          return { success: true, message: 'If an account exists, a magic link has been sent', errors: [] };
+        }
+
+        if (user.status !== 'ACTIVE') {
+          throw new ForbiddenError('Account is not active');
+        }
+
+        const token = await TokenService.generateMagicLinkToken(user.id);
+        await EmailService.sendMagicLinkEmail(user.email, token, redirectUri);
+
+        await auditLog('MAGIC_LINK_REQUESTED', user.id, { ip: req.ip });
+
+        return { success: true, message: 'Magic link sent', errors: [] };
+      } catch (error) {
+        if (error instanceof UserInputError || error instanceof ForbiddenError) {
+          throw error;
+        }
+
+        console.error('Magic link request error:', error);
+        throw new Error('Failed to send magic link');
+      }
+    },
+
+    async loginWithMagicLink(parent, { token }, context) {
+      const { req, res, pubsub } = context;
+
+      try {
+        await rateLimitCheck(req, 'magic_link_login', 5, 900);
+
+        const decoded = await TokenService.verifyMagicLinkToken(token);
+        const user = await UserService.findById(decoded.userId);
+
+        if (!user || user.status !== 'ACTIVE') {
+          throw new AuthenticationError('Invalid or expired magic link');
+        }
+
+        const { accessToken, refreshToken, expiresIn } = await TokenService.generateTokens(user);
+
+        res.cookie('token', accessToken, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'strict',
+          maxAge: expiresIn * 1000
+        });
+        res.cookie('refreshToken', refreshToken, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'strict',
+          maxAge: 30 * 24 * 60 * 60 * 1000
+        });
+
+        await auditLog('MAGIC_LINK_LOGIN', user.id, { ip: req.ip });
+
+        pubsub.publish('AUTH_STATUS_CHANGED', {
+          authStatusChanged: {
+            userId: user.id,
+            action: 'MAGIC_LINK_LOGIN',
+            timestamp: new Date(),
+            metadata: {}
+          }
+        });
+
+        return {
+          success: true,
+          accessToken,
+          refreshToken,
+          user,
+          requirePasswordReset: false,
+          expiresIn,
+          tokenType: 'Bearer',
+          errors: []
+        };
+      } catch (error) {
+        if (error instanceof AuthenticationError || error instanceof ForbiddenError || error instanceof UserInputError) {
+          throw error;
+        }
+
+        console.error('Magic link login error:', error);
+        throw new Error('Magic link login failed');
       }
     },
 

--- a/backend/src/graphql/schema/auth.schema.js
+++ b/backend/src/graphql/schema/auth.schema.js
@@ -27,6 +27,11 @@ module.exports = gql`
     redirectUri: String
   }
 
+  input MagicLinkRequestInput {
+    email: EmailAddress!
+    redirectUri: String
+  }
+
   input PasswordResetInput {
     token: String!
     newPassword: String!
@@ -100,6 +105,8 @@ module.exports = gql`
     login(input: LoginInput!): AuthPayload!
     signup(input: SignupInput!): SignupPayload!
     socialLogin(input: SocialLoginInput!): AuthPayload!
+    requestMagicLink(input: MagicLinkRequestInput!): SuccessPayload!
+    loginWithMagicLink(token: String!): AuthPayload!
     logout: SuccessPayload!
     
     # Password management

--- a/backend/src/services/email.service.js
+++ b/backend/src/services/email.service.js
@@ -198,6 +198,48 @@ class EmailService {
   }
 
   /**
+   * Send magic login link email
+   * @param {string} email - Recipient email
+   * @param {string} token - Magic link token
+   * @param {string} [redirectUri] - Optional redirect after login
+   */
+  async sendMagicLinkEmail(email, token, redirectUri) {
+    const baseUrl = `${process.env.FRONTEND_URL}/magic-login?token=${token}`;
+    const loginUrl = redirectUri ? `${baseUrl}&redirect=${encodeURIComponent(redirectUri)}` : baseUrl;
+
+    const mailOptions = {
+      from: {
+        name: 'Auth SaaS',
+        address: process.env.EMAIL_USER
+      },
+      to: email,
+      subject: 'Your Magic Login Link',
+      html: this.getMagicLinkEmailTemplate(loginUrl),
+      text: `Sign in using this link: ${loginUrl}`
+    };
+
+    try {
+      const result = await this.transporter.sendMail(mailOptions);
+      await auditLog('EMAIL_SENT', null, {
+        type: 'MAGIC_LINK',
+        email,
+        messageId: result.messageId
+      });
+
+      return { success: true, messageId: result.messageId };
+    } catch (error) {
+      console.error('Failed to send magic link email:', error);
+      await auditLog('EMAIL_FAILED', null, {
+        type: 'MAGIC_LINK',
+        email,
+        error: error.message
+      });
+
+      throw new Error('Failed to send magic link email');
+    }
+  }
+
+  /**
    * Send welcome email
    * @param {string} email - Recipient email
    * @param {string} username - User's username
@@ -390,6 +432,48 @@ class EmailService {
             <p>If the button doesn't work, you can copy and paste this link into your browser:</p>
             <p style="word-break: break-all; color: #28a745;">${acceptUrl}</p>
             <p>This invitation will expire in 7 days.</p>
+          </div>
+          <div class="footer">
+            <p>&copy; 2024 Auth SaaS. All rights reserved.</p>
+          </div>
+        </div>
+      </body>
+      </html>
+    `;
+  }
+
+  /**
+   * Get magic link email template
+   * @param {string} loginUrl - Magic login URL
+   * @returns {string} - HTML template
+   */
+  getMagicLinkEmailTemplate(loginUrl) {
+    return `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <meta charset="utf-8">
+        <title>Your Magic Login Link</title>
+        <style>
+          body { font-family: Arial, sans-serif; line-height: 1.6; margin: 0; padding: 20px; }
+          .container { max-width: 600px; margin: 0 auto; background: #f9f9f9; padding: 20px; }
+          .header { background: #4f46e5; color: white; padding: 20px; text-align: center; }
+          .content { background: white; padding: 30px; }
+          .button { display: inline-block; padding: 12px 24px; background: #4f46e5; color: white; text-decoration: none; border-radius: 5px; margin: 20px 0; }
+          .footer { text-align: center; color: #666; margin-top: 30px; }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <div class="header">
+            <h1>Magic Login Link</h1>
+          </div>
+          <div class="content">
+            <p>Click the button below to sign in:</p>
+            <a href="${loginUrl}" class="button">Sign In</a>
+            <p>If the button doesn't work, copy and paste this link into your browser:</p>
+            <p style="word-break: break-all; color: #4f46e5;">${loginUrl}</p>
+            <p>This link will expire in 15 minutes.</p>
           </div>
           <div class="footer">
             <p>&copy; 2024 Auth SaaS. All rights reserved.</p>

--- a/backend/src/services/token.service.js
+++ b/backend/src/services/token.service.js
@@ -263,6 +263,38 @@ class TokenService {
   }
 
   /**
+   * Generate magic link login token
+   * @param {string} userId - User ID
+   * @returns {Promise<string>} - Magic link token
+   */
+  async generateMagicLinkToken(userId) {
+    const payload = {
+      userId,
+      type: 'magic_link',
+      purpose: 'MAGIC_LINK_LOGIN'
+    };
+
+    return jwt.sign(
+      payload,
+      this.getAccessTokenSecret(),
+      {
+        expiresIn: '15m',
+        issuer: 'auth-saas',
+        audience: 'auth-saas-client'
+      }
+    );
+  }
+
+  /**
+   * Verify magic link token
+   * @param {string} token - Token to verify
+   * @returns {Promise<Object>} - Decoded token
+   */
+  async verifyMagicLinkToken(token) {
+    return this.verifySpecialToken(token, 'magic_link');
+  }
+
+  /**
    * Verify special purpose token (verification, reset, etc.)
    * @param {string} token - Token to verify
    * @param {string} expectedType - Expected token type

--- a/backend/src/validators/auth.validators.js
+++ b/backend/src/validators/auth.validators.js
@@ -124,6 +124,17 @@ const passwordResetRequestSchema = Joi.object({
     })
 }).options({ stripUnknown: true });
 
+// Magic link request validation schema
+const magicLinkRequestSchema = Joi.object({
+  email: emailSchema,
+  redirectUri: Joi.string()
+    .uri()
+    .allow('')
+    .messages({
+      'string.uri': 'Invalid redirect URI'
+    })
+}).options({ stripUnknown: true });
+
 // Password reset validation schema
 const passwordResetSchema = Joi.object({
   token: Joi.string()
@@ -305,6 +316,7 @@ module.exports = {
   passwordResetRequestSchema,
   passwordResetSchema,
   changePasswordSchema,
+  magicLinkRequestSchema,
   emailVerificationSchema,
   tokenValidationSchema,
   refreshTokenSchema,


### PR DESCRIPTION
## Summary
- implement magic-link token generation and verification
- add email service method for sending magic login links with template
- validate magic link request input
- extend auth GraphQL schema and resolvers for requesting/login via magic link

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ca3e6e7e8832f92eeaa9b5ac127ef